### PR TITLE
Add questio to Tools > Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools — merge, split, compress, OCR, sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools with no signup. Merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF.
 - [pdfparanoia](https://github.com/kanzure/pdfparanoia) - Watermark removal tool in Python.
+- [questio](https://github.com/abcreativ/questio) - Forensic PDF auditor CLI for detecting edited, forged, or tampered PDFs. Runs locally, no uploads.
 
 ## Software
 


### PR DESCRIPTION
Adds [questio](https://github.com/abcreativ/questio), a forensic PDF auditor CLI, to Tools > Misc.

questio detects edited, forged, or tampered PDFs by examining font session tags, revision history markers, Acrobat edit signatures, and producer metadata. Python 3.10+, MIT licensed, pip-installable, runs entirely locally (no uploads).

Sits naturally next to pdfparanoia (another Python-based PDF security CLI in the same section).