### PR TITLE
Add DoItSwift to PDF tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [nodeice](https://github.com/IonicaBizau/nodeice) - PDF invoice generator.
 - [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools — merge, split, compress, OCR, sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools with no signup. Merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF.
+- [DoItSwift](https://doitswift.com/pdf/) - Free browser-based PDF tools — merge, split, compress, and PDF to JPG. No Server/Cloud upload, no signup. Everything runs locally in your browser.
 - [pdfparanoia](https://github.com/kanzure/pdfparanoia) - Watermark removal tool in Python.
 
 ## Software


### PR DESCRIPTION
DoItSwift (https://doitswift.com) is a free, privacy-first toolkit with  browser-based PDF tools:

- Merge PDF — combine multiple PDFs into one
- Split PDF — extract pages into separate files
- Compress PDF — reduce file size
- PDF to JPG — convert PDF pages to images

Files are processed entirely in the browser using native JavaScript and  PDF-LIB. No files are sent to any server, no signup required, no ads.  Verifiable in browser DevTools (zero outbound requests during conversion).

Fits the Tools/Misc section alongside PDFGem and Fluranto, which are also browser-based privacy-focused PDF toolkits.