### PR TITLE
Add AllPDFMagic to Misc section (online PDF tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [nodeice](https://github.com/IonicaBizau/nodeice) - PDF invoice generator.
 - [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools — merge, split, compress, OCR, sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools with no signup. Merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF.
+- [AllPDFMagic](https://allpdfmagic.com) - Free online PDF toolbox with 33+ tools and AI-powered workflows. Merge, split, compress, convert, edit, sign, and protect PDFs with zero signup. Features AI Summarizer, Invoice Extractor, Contract Analyzer, and Multi-PDF Chat.
 - [pdfparanoia](https://github.com/kanzure/pdfparanoia) - Watermark removal tool in Python.
 
 ## Software


### PR DESCRIPTION
## Summary

Add [AllPDFMagic](https://allpdfmagic.com) to the Tools > Misc section of awesome-pdf.

AllPDFMagic is a free online PDF toolbox offering 33+ tools including:
- Merge, split, compress, convert, edit, sign, and protect PDFs
- AI-powered workflows: AI Summarizer, Invoice Extractor, Contract Analyzer
- No signup required — all tools work directly in the browser
- 256-bit SSL encryption, files deleted within 1 hour

This is a natural fit for the Misc section alongside similar online PDF tools like PDFGem, Fluranto, and Sejda.

## Checklist
- [x] Entry is added to the correct section
- [x] Description is factual and concise
- [x] No affiliate links or tracking