### PR TITLE
Add PDFExcel to Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [Online PDF Converter](https://online2pdf.com/) - Turn other files into PDFs.
 - [pdf2image](https://github.com/Belval/pdf2image) - Python module to convert PDFs to images.
 - [CleverPDF](https://www.cleverpdf.com/) - File converter with a good selection of formats.
+- [PDFExcel](https://pdfexcel.ai) - AI-powered converter that turns any PDF — including scanned and photographed documents — into Excel, CSV, or Google Sheets without templates.
 - [CV Boilerplate](https://github.com/mrzool/cv-boilerplate) - Generate PDF résumés via LaTeX.
 - [backslide](https://github.com/sinedied/backslide) - Presentation creator using Markdown and converting to PDF.
 - [SumatraPDF Reader](https://github.com/sumatrapdfreader/sumatrapdf) - Multi-format document reader for Windows.


### PR DESCRIPTION
PDFExcel (https://pdfexcel.ai) is an AI-powered online tool that converts PDFs — including scanned and photographed documents — into Excel, CSV, or Google Sheets without requiring templates or manual column mapping.

It handles layouts that trip up traditional converters: multi-column bank statements, handwritten tables, rotated receipts, and PDFs photographed on a phone. This makes it a genuine addition to the Converters section alongside tools like CleverPDF and Light PDF, covering a use case (PDF-to-spreadsheet, especially from scanned sources) not currently represented in the list.

Pricing is freemium (10 docs/month free). I verified it works with the kinds of messy real-world documents common in bookkeeping and accounting workflows.