### PR TITLE
Add PDF Toolbox — privacy-first browser PDF tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [Rails PDF](https://github.com/igorkasyanchuk/rails_pdf) - Create PDF documents from HTML in Ruby on Rails.
 
 ## Tools
+- [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools. Compress, merge, split, convert. All local WebAssembly processing — no file uploads.
 
 ### Converters
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ If you have a question or aren’t sure if something is worth including, you can
 - [questio](https://github.com/abcreativ/questio) - Forensic PDF auditor CLI for detecting edited, forged, or tampered PDFs. Runs locally, no uploads.
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based PDF utilities with no signup. Includes Chat with PDF (ask questions about a PDF) and PDF to Markdown (extract structured Markdown from PDFs). Client-side processing; part of a larger suite of single-purpose web tools. Open source.
 
+- [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free, privacy-first online PDF toolkit — merge, split, compress, convert, OCR, e-sign, and more. All processing is client-side; files never leave the browser.
+
 ## Software
 
 - [Foxit Software](https://www.foxit.com/) - Multiple PDF-related products and other resources.


### PR DESCRIPTION
Add [PDF Toolbox](https://pdftoolbox-three.vercel.app) — free browser-based PDF tools. Compress, merge, split, PDF↔JPG, unlock PDF. All processing is local (WebAssembly), no file uploads, no account needed.