### PR TITLE
Add pdf_oxide to the Rust libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ If you have a question or aren’t sure if something is worth including, you can
 
 ### Rust
 - [lopdf](https://github.com/J-F-Liu/lopdf) - Rust PDF manipulation.
+- [pdf_oxide](https://github.com/yfedoseev/pdf_oxide) - Fast Rust PDF library with text and image extraction, markdown conversion, and bindings for many languages.
 - [printpdf](https://github.com/fschutt/printpdf) - Create printable PDF documents.
 
 ### Misc/Multi-language


### PR DESCRIPTION
Adds [pdf_oxide](https://github.com/yfedoseev/pdf_oxide) to the `### Rust` section (alphabetically, between lopdf and printpdf), matching the existing one-line format.

> - [pdf_oxide](https://github.com/yfedoseev/pdf_oxide) - Fast Rust PDF library with text and image extraction, markdown conversion, and bindings for many languages.

pdf_oxide is an MIT-licensed Rust-core PDF toolkit (text/image extraction, markdown & HTML→PDF, PDF creation/editing) with bindings for Python, Go, JS/TS, C#/.NET, Java, PHP, Ruby, and WASM. Thanks for maintaining the list!