### PR TITLE
Add HTPBE? — forensic PDF tamper-detection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ If you have a question or aren’t sure if something is worth including, you can
 
 - [URL to PDF Microservice](https://github.com/alvarcarto/url-to-pdf-api) - Convert HTML to PDF files.
 - [DocRaptor](https://docraptor.com/) - HTML to PDF API.
+- [HTPBE?](https://htpbe.tech/api) - Forensic API that detects tampered/modified PDFs from the structural layer (metadata, xref, incremental updates, signatures); works without the original file.
 - [RichText2Pdf API](https://rapidapi.com/convertapi/api/richtext2pdf/details) - Convert rich text documents to PDF.
 - [Excel2Pdf API](https://english.api.rakuten.net/convertapi/api/excel2pdf) - Convert Excel docs to PDF files.
 - [DOCX to PDF API](https://www.convertapi.com/docx-to-pdf) - Convert Word to PDF.


### PR DESCRIPTION
Adds **HTPBE?** to the **APIs** section.

[HTPBE?](https://htpbe.tech/api) is a forensic API (plus a free web tool) that detects whether a PDF was **modified after creation** from the structural layer — metadata, xref tables, incremental updates, and digital signatures — **without the original file**.

This is the same forensic-PDF category as the existing `questio` entry under Tools > Misc, but offered as a hosted API, so it slots into the `APIs` section. One line, matching the `- [Name](url) - Description.` format. Thanks for curating this list!