### PR TITLE
Add HTPBE (forensic PDF tamper-detection API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ If you have a question or aren’t sure if something is worth including, you can
 
 ## APIs
 
+- [HTPBE](https://htpbe.tech/api) - Forensic API that detects tampered/modified PDFs from the structural layer (metadata, xref, incremental updates, signatures); works without the original file.
 - [URL to PDF Microservice](https://github.com/alvarcarto/url-to-pdf-api) - Convert HTML to PDF files.
 - [DocRaptor](https://docraptor.com/) - HTML to PDF API.
 - [RichText2Pdf API](https://rapidapi.com/convertapi/api/richtext2pdf/details) - Convert rich text documents to PDF.


### PR DESCRIPTION
Adds HTPBE to the **APIs** section.

HTPBE is a hosted forensic API that detects whether a PDF was modified/tampered after creation by reading the structural layer (metadata, xref tables, incremental updates, digital signatures) — it works without the original file. It's a direct peer of the existing `questio` forensic-PDF entry under Tools, exposed as an API.

- Site/API: https://htpbe.tech/api