### PR TITLE
Add ng2-pdfjs-viewer (Angular PDF viewer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [pdfmake](http://pdfmake.org/#/) - Wrapper for PDFKit offering a few extra features.
 - [PDF-LIB](https://pdf-lib.js.org/) - Pure JavaScript PDF library.
 - [PDF.js](https://mozilla.github.io/pdf.js/) - Standards-based, general-purpose viewer.
+- [ng2-pdfjs-viewer](https://github.com/intbot/ng2-pdfjs-viewer) - Angular PDF viewer component built on PDF.js (annotations, forms, signatures, search, read-aloud).
 - [jsPDF](https://github.com/MrRio/jsPDF) - Advanced, well-documented library.
 - [labelmake](https://labelmake.jp/javascript-pdf-generator-library/) - Simple PDF generator.
 - [Puppeteer](https://github.com/puppeteer/puppeteer) - Node library for controlling Chrome. Can also generate PDFs.


### PR DESCRIPTION
Adds **ng2-pdfjs-viewer**, an Angular PDF viewer built on Mozilla PDF.js (on npm since 2018, 8.3M+ downloads, Angular 10 through 22): annotations, AcroForms, signatures, search, page organization, and read-aloud from one component.

- npm: https://www.npmjs.com/package/ng2-pdfjs-viewer
- repo: https://github.com/intbot/ng2-pdfjs-viewer
