### PR TITLE
Add Codegrain (browser-based PDF/image/data tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based PDF utilities with no signup. Includes Chat with PDF (ask questions about a PDF) and PDF to Markdown (extract structured Markdown from PDFs). Client-side processing; part of a larger suite of single-purpose web tools. Open source.
 
 - [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free, privacy-first online PDF toolkit — merge, split, compress, convert, OCR, e-sign, and more. All processing is client-side; files never leave the browser.
+- [Codegrain](https://private-tools.codegrain.dev) - Free suite of browser-based PDF, image and data tools (merge, split, compress, sign, HEIC→JPG, EXIF removal, compress-to-target-size); every file is processed client-side with no upload, account or limits.
 
 ## Software
 


### PR DESCRIPTION
Adds Codegrain under Tools › Misc.

A free suite of browser-based tools for PDF, images and data — PDF merge/split/compress/sign, PDF→JPG, plus image and data utilities. All processing happens client-side; files are never uploaded, no account, no limits.

Fits alongside the existing hosted suites (e.g. Sejda), and adds PDF-adjacent utilities those skip (HEIC→JPG, EXIF/metadata removal, compress-to-an-exact-target-size).

- Link: https://private-tools.codegrain.dev
- How privacy works (verify in DevTools): https://private-tools.codegrain.dev/en/how-privacy-works

Disclosure: I'm the author of this project. Not open-source at this time.
