### PR TITLE
Add Oicana to Misc/Multi-language

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If you have a question or aren’t sure if something is worth including, you can
 
 ### Misc/Multi-language
 
+- [Oicana](https://oicana.com) - Tools and libraries for document templating based on Typst. Supports Node.js, Python, Java, C#, Rust, PHP, and the browser.
 - [electron-pdf-window](https://github.com/gerhardberger/electron-pdf-window) - PDF support in the Electron framework.
 - [Gmail To PDF](https://github.com/pixelcog/gmail-to-pdf) - Google Apps script utilities to convert emails to PDF.
 - [pdf-toolbox](https://github.com/Yuras/pdf-toolbox) - Haskell PDF processing tools.


### PR DESCRIPTION
I first had multiple entries in the supported languages, but I guess you would prefer the single entry in Misc/Multi-language?

Oicana has native libraries for different programming languages that all work with the same template format. The templates use Typst and define their own data inputs. A CLI helps developing the templates with support for snapshot testing, json schema validation for inputs and template packing.

I'm the author of Oicana.