### PR TITLE
Add Slay PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [nodeice](https://github.com/IonicaBizau/nodeice) - PDF invoice generator.
 - [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools — merge, split, compress, OCR, sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser.
 - [PDFSass](https://pdfsass.com/) - Free browser-based PDF toolkit with 35+ tools — merge, split, compress, convert, OCR, rotate, watermark, sign, and more. No signup required; files processed in-browser via WebAssembly.
+- [Slay PDF](https://slaypdf.com/) - Free local browser PDF editor for splitting, merging, signing, resizing, posterising, OCR and page editing. Open source and client-side.
 - [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools with no signup. Merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF.
 - [DoItSwift](https://doitswift.com/pdf/) - Free browser-based PDF tools — merge, split, compress, and PDF to JPG. No Server/Cloud upload, no signup. Everything runs locally in your browser.
 - [AllPDFMagic](https://allpdfmagic.com) - Free online PDF toolbox with 33+ tools and AI-powered workflows. Merge, split, compress, convert, edit, sign, and protect PDFs with zero signup. Features AI Summarizer, Invoice Extractor, Contract Analyzer, and Multi-PDF Chat.


### PR DESCRIPTION
Adds Slay PDF to the Tools/Misc section as a free local browser PDF editor. It fits near the existing browser PDF utilities and keeps the description short and factual.