### PR TITLE
Add OnDevicePDF to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ If you have a question or aren’t sure if something is worth including, you can
 ## Tools
 - [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools. Compress, merge, split, convert. All local WebAssembly processing — no file uploads.
 - [hushvert](https://hushvert.com) - Privacy-first browser-based PDF tools. Merge, split, rotate, and render PDFs locally via WebAssembly with no file uploads, plus a hosted API for PDF to Word and Office to PDF.
+- [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF tools — merge, split, compress, edit, sign, OCR. The security tools (password protect/remove/recover, redact) run under a sealed CSP so files provably never leave the browser; live proof at [ondevicepdf.com/verify](https://www.ondevicepdf.com/verify).
 
 ### Converters
 


### PR DESCRIPTION
Adds OnDevicePDF — free browser-based PDF tools (merge, split, compress, edit, sign, OCR, and more), no signup, works offline as a PWA.

What's distinctive vs. the other browser-based entries: the four security tools (password protect, remove password, recover forgotten password, redact) run under a sealed Content-Security-Policy (`connect-src 'self'`), so "no file uploads" is enforced by the browser itself rather than promised — verifiable in DevTools or at https://www.ondevicepdf.com/verify.

Disclosure: I'm the developer.
