### PR TITLE
Add paper2md — academic PDF to Markdown converter with LaTeX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [backslide](https://github.com/sinedied/backslide) - Presentation creator using Markdown and converting to PDF.
 - [SumatraPDF Reader](https://github.com/sumatrapdfreader/sumatrapdf) - Multi-format document reader for Windows.
 - [Markdown Resume Generator](https://github.com/there4/markdown-resume) - PHP tool to convert markdown to PDF and HTML résumés.
+- [paper2md](https://paper2md.com/) - Web tool to convert academic and technical PDFs into clean Markdown. Preserves LaTeX formulas (KaTeX/MathJax/Obsidian compatible), converts complex research tables to valid GFM Markdown, and extracts figures into a ZIP. Free for 100 pages/month.
 
 ### Misc
 


### PR DESCRIPTION
## What
Adds [paper2md](https://paper2md.com) to the Converters section.

## Why
paper2md is specifically designed for academic and technical PDFs — it handles the hard parts that break most converters:

- **LaTeX formula preservation** — multi-line equations normalized to KaTeX/MathJax/Obsidian-compatible `$...$` and `$$...$$` delimiters, with correct handling of `\tag{}` and `\align` environments
- **Complex table conversion** — borderless and multi-row research tables converted to valid GFM Markdown
- **Multi-column layout** — arXiv-style double-column papers parsed with correct reading order
- **Image extraction** — figures extracted and packaged as a ZIP with relative paths

**Verified on real arXiv papers:** 79 LaTeX formulas, 0 rendering errors on a 12-page double-column paper (ResNet, arXiv:1512.03385).

**Free tier:** 100 pages/month, no credit card required.