### PR TITLE
Add Brainiall PDF to Markdown Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [Light PDF](https://lightpdf.com/) - Converter and other tools.
 - [Online PDF Converter](https://online2pdf.com/) - Turn other files into PDFs.
 - [pdf2image](https://github.com/Belval/pdf2image) - Python module to convert PDFs to images.
+- [Brainiall PDF to Markdown Action](https://github.com/fasuizu-br/brainiall-pdf-to-markdown-action) - GitHub Action that converts PDF files to Markdown through the hosted Brainiall API.
 - [CleverPDF](https://www.cleverpdf.com/) - File converter with a good selection of formats.
 - [PDFExcel](https://pdfexcel.ai) - AI-powered converter that turns any PDF — including scanned and photographed documents — into Excel, CSV, or Google Sheets without templates.
 - [CV Boilerplate](https://github.com/mrzool/cv-boilerplate) - Generate PDF résumés via LaTeX.


### PR DESCRIPTION
## Summary

- Add Brainiall PDF to Markdown Action to **Tools > Converters**.

## Fit

The public GitHub Action converts PDF files to Markdown through the hosted Brainiall API, matching the converter section. The entry is one factual line and links to the public MIT-licensed repository.

Disclosure: the submitting organization maintains this Action.

## Validation

- Confirmed that the README welcomes new links through pull requests.
- Checked the current README, issues, pull requests, and open pull-request patches for a duplicate Brainiall entry.
- Confirmed that the repository and its v1.0.0 release are public.
- Ran `git diff --check upstream/main...HEAD`.
