### PR TITLE
Add CopyMarkdown to Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [SumatraPDF Reader](https://github.com/sumatrapdfreader/sumatrapdf) - Multi-format document reader for Windows.
 - [Markdown Resume Generator](https://github.com/there4/markdown-resume) - PHP tool to convert markdown to PDF and HTML résumés.
 - [paper2md](https://paper2md.com/) - Web tool to convert academic and technical PDFs into clean Markdown. Preserves LaTeX formulas (KaTeX/MathJax/Obsidian compatible), converts complex research tables to valid GFM Markdown, and extracts figures into a ZIP. Free for 100 pages/month.
+- [CopyMarkdown](https://copymarkdown.com/pdf-to-markdown/) - Free web tool to convert PDFs to clean Markdown. A companion [Chrome extension](https://chromewebstore.google.com/detail/bafbipicilofikmmjdeckfjghfdffdgp) converts webpages and AI chat conversations, and a separate free web tool converts GitHub repos. No signup required.
 
 ### Misc
 


### PR DESCRIPTION
Adds [CopyMarkdown](https://copymarkdown.com/pdf-to-markdown/) to the Converters section — a free, no-signup web tool that converts PDFs to clean Markdown. The same site offers a Chrome extension for webpage/AI-chat conversion and a web tool for GitHub repos.

Appended after paper2md, matching the section's existing format and append order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)