### PR TITLE
Add PDF Mavericks (browser-local PDF toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools. Compress, merge, split, convert. All local WebAssembly processing — no file uploads.
 - [hushvert](https://hushvert.com) - Privacy-first browser-based PDF tools. Merge, split, rotate, and render PDFs locally via WebAssembly with no file uploads, plus a hosted API for PDF to Word and Office to PDF.
 - [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF tools — merge, split, compress, edit, sign, OCR. The security tools (password protect/remove/recover, redact) run under a sealed CSP so files provably never leave the browser; live proof at [ondevicepdf.com/verify](https://www.ondevicepdf.com/verify).
+- [PDF Mavericks](https://www.pdfmavericks.com) - Free browser-based PDF tools — merge, split, compress, rotate, sign, unlock, OCR, and conversions to text, Markdown, CSV and EPUB. Processing runs client-side via WebAssembly and pdf-lib; no upload, no account.
 
 ### Converters
 


### PR DESCRIPTION
Adds [PDF Mavericks](https://www.pdfmavericks.com) to Tools, alongside the other browser-local toolkits in that section.

It is a free, no-account PDF toolkit that runs entirely in the browser — merge, split, compress, rotate, sign, unlock, OCR, plus conversions to text, Markdown, CSV and EPUB. Processing runs client-side in JavaScript/wasm (pdf-lib, pdf.js, Tesseract), so files never reach a server. No tracking beyond anonymous usage analytics.

Hope this fits the list. Happy to adjust the entry text or move it to a different section.