### PR TITLE
Add PDF Local Processor to JavaScript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDFKit (JavaScript)](https://pdfkit.org/) - JavaScript PDF generation library. For Node and the browser.
 - [pdfmake](http://pdfmake.org/#/) - Wrapper for PDFKit offering a few extra features.
 - [PDF-LIB](https://pdf-lib.js.org/) - Pure JavaScript PDF library.
+- [PDF Local Processor](https://github.com/privitools/pdf-local-processor) - Browser helpers for extracting native PDF text, rewriting PDFs, and converting images to PDF without uploading input bytes.
 - [PDF.js](https://mozilla.github.io/pdf.js/) - Standards-based, general-purpose viewer.
 - [ng2-pdfjs-viewer](https://github.com/intbot/ng2-pdfjs-viewer) - Angular PDF viewer component built on PDF.js (annotations, forms, signatures, search, read-aloud).
 - [jsPDF](https://github.com/MrRio/jsPDF) - Advanced, well-documented library.


### PR DESCRIPTION
## Changes

Adds PDF Local Processor to the JavaScript section. It is a small browser library for extracting the text layer from native PDFs, rewriting PDFs structurally, and converting JPEG/PNG files to PDF without uploading input bytes.

## Supporting material

- Repository: https://github.com/privitools/pdf-local-processor
- Release: https://github.com/privitools/pdf-local-processor/releases/tag/v1.0.3
- CI: https://github.com/privitools/pdf-local-processor/actions

## Affiliation

I am the maintainer of PDF Local Processor and am disclosing that affiliation here.
