### PR TITLE
Add In-Tab Tools to Tools > Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDF Tool HQ](https://pdftoolhq.com/) - Free browser-based PDF tools to merge, split, and compress. Runs entirely client-side, so files never leave your device. No upload, no sign-up, no watermarks.
 - [PDF Tool HQ](https://pdftoolhq.com/) - Free browser-based PDF tools to merge, split, and compress. Runs entirely client-side, so files never leave your device. No upload, no sign-up, no watermarks.
 - [KeyPDF](https://keypdf.net) - An independent, client-side PDF engine for editing existing PDF text, merges, annotations and filling forms directly in the browser without uploading files.
+- [In-Tab Tools](https://intabtools.com/pdf/pdf-to-md) - Browser-based PDF tools: convert PDF to Markdown, convert Markdown to PDF, and remove PDF metadata (author, producer, etc). All processing runs client-side in the browser tab; no file is uploaded and no account is required. PDF-to-Markdown reads the PDF's existing text layer, so a scanned PDF with no text layer cannot be converted (no OCR).
+
 ## Software
 
 - [Foxit Software](https://www.foxit.com/) - Multiple PDF-related products and other resources.


### PR DESCRIPTION
Adds In-Tab Tools (https://intabtools.com), a browser-based toolset that includes PDF↔Markdown conversion and PDF metadata removal.

- PDF to Markdown: https://intabtools.com/pdf/pdf-to-md
- Markdown to PDF: https://intabtools.com/pdf/markdown-to-pdf
- PDF metadata remover: https://intabtools.com/pdf/pdf-metadata-remover

All processing runs client-side in the browser tab — no file is uploaded, no account required, no AI involved. The PDF-to-Markdown tool reads the PDF's existing text layer, so scanned PDFs with no text layer cannot be converted (there is no OCR); the tool states this limitation rather than silently returning an empty result.

Added one line to Tools > Misc, matching the style of nearby entries (norito, PDF Tool HQ, KeyPDF).