### PR TITLE
Add PolyDoc to APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [HTPBE](https://htpbe.tech/api) - Forensic API that detects tampered/modified PDFs from the structural layer (metadata, xref, incremental updates, signatures); works without the original file.
 - [URL to PDF Microservice](https://github.com/alvarcarto/url-to-pdf-api) - Convert HTML to PDF files.
 - [DocRaptor](https://docraptor.com/) - HTML to PDF API.
+- [PolyDoc](https://polydoc.tech/) - HTML to PDF and screenshots, with PDF/A and tagged PDF/UA output and an optional veraPDF check that fails the request instead of returning a non-conforming file.
 - [HTPBE?](https://htpbe.tech/api) - Forensic API that detects tampered/modified PDFs from the structural layer (metadata, xref, incremental updates, signatures); works without the original file.
 - [RichText2Pdf API](https://rapidapi.com/convertapi/api/richtext2pdf/details) - Convert rich text documents to PDF.
 - [Excel2Pdf API](https://english.api.rakuten.net/convertapi/api/excel2pdf) - Convert Excel docs to PDF files.


### PR DESCRIPTION
Adds PolyDoc to the APIs section, next to DocRaptor since it is the closest neighbour.

[PolyDoc](https://polydoc.tech/) is a hosted HTML/URL to PDF and screenshot API. The reason it is worth a line rather than being one more converter: it emits PDF/A and tagged PDF/UA-1 and can run [veraPDF](https://verapdf.org/) as part of the same request, returning an error instead of a document when the file does not conform. Most APIs in this section either do not target those formats or emit them without checking.

Free tier is 150 conversions a month, no card, if you want to verify the output before merging.

Unrelated heads-up, not touched in this PR to keep the diff to one line: the APIs section lists HTPBE twice, once as `HTPBE` and once as `HTPBE?`, both pointing at https://htpbe.tech/api. Happy to open a separate PR removing the duplicate if useful.