### PR TITLE
Add PDFForYou to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [hushvert](https://hushvert.com) - Privacy-first browser-based PDF tools. Merge, split, rotate, and render PDFs locally via WebAssembly with no file uploads, plus a hosted API for PDF to Word and Office to PDF.
 - [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF tools — merge, split, compress, edit, sign, OCR. The security tools (password protect/remove/recover, redact) run under a sealed CSP so files provably never leave the browser; live proof at [ondevicepdf.com/verify](https://www.ondevicepdf.com/verify).
 - [norito](https://norito.in/pdf/) — Free browser-based PDF tools: merge, split, compress, rotate, sign, watermark, extract text, and compare two PDFs. All client-side via pdf-lib and pdf.js, no file uploads.
+- [PDFForYou](https://pdfforyou.in) - Free browser-based PDF & image toolkit — merge, split, compress, crop, sign, watermark, convert — plus a passport/ID photo cropper with presets for multiple countries, an invoice generator, and a rent receipt generator. All client-side via pdf.js and pdf-lib, no file uploads.
 
 ### Converters
 


### PR DESCRIPTION
Adds PDFForYou (https://pdfforyou.in) to the Tools section — a free, browser-based PDF & image toolkit (merge, split, compress, crop, sign, watermark, convert) plus a passport/ID photo cropper with country-specific presets, an invoice generator, and a rent receipt generator. All processing runs client-side via pdf.js and pdf-lib, no file uploads.