### PR TITLE
Add Inko to Libraries > JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDF-LIB](https://pdf-lib.js.org/) - Pure JavaScript PDF library.
 - [PDF.js](https://mozilla.github.io/pdf.js/) - Standards-based, general-purpose viewer.
 - [ng2-pdfjs-viewer](https://github.com/intbot/ng2-pdfjs-viewer) - Angular PDF viewer component built on PDF.js (annotations, forms, signatures, search, read-aloud).
+- [Inko](https://github.com/sinabin/inko-sdk) - Self-hosted PDF annotation SDK that returns review state as a separate value for host-managed storage.
 - [jsPDF](https://github.com/MrRio/jsPDF) - Advanced, well-documented library.
 - [labelmake](https://labelmake.jp/javascript-pdf-generator-library/) - Simple PDF generator.
 - [Puppeteer](https://github.com/puppeteer/puppeteer) - Node library for controlling Chrome. Can also generate PDFs.


### PR DESCRIPTION
Adds Inko, an Apache-2.0 self-hosted PDF annotation SDK built on PDF.js.

It differs from the PDF entries already listed: instead of writing annotations
into the PDF, it returns editing state as a separate serializable value the host
application stores, which allows several reviewers' markup to be overlaid and
editing to resume from a selected state.

- Repo: https://github.com/sinabin/inko-sdk
- npm: https://www.npmjs.com/package/inko-pdf-sdk
- License: Apache-2.0
- Docs: README, integration guide, architecture and data-flow docs in-repo
- Tests: 613 unit tests, 44 browser E2E specs, a 120-page performance gate, and
  coverage thresholds, all enforced in CI

Checked for duplicates; no existing entry for this project.