### PR TITLE
Add A Box of Tools to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [hushvert](https://hushvert.com) - Privacy-first browser-based PDF tools. Merge, split, rotate, and render PDFs locally via WebAssembly with no file uploads, plus a hosted API for PDF to Word and Office to PDF.
 - [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF tools — merge, split, compress, edit, sign, OCR. The security tools (password protect/remove/recover, redact) run under a sealed CSP so files provably never leave the browser; live proof at [ondevicepdf.com/verify](https://www.ondevicepdf.com/verify).
 - [norito](https://norito.in/pdf/) — Free browser-based PDF tools: merge, split, compress, rotate, sign, watermark, extract text, and compare two PDFs. All client-side via pdf-lib and pdf.js, no file uploads.
+- [A Box of Tools](https://abox.tools/) - Free browser-based PDF tools: merge, compress, redact, and images to PDF. The redaction deletes the glyphs from the content stream instead of covering them, so the words are not still selectable underneath. Open source (MIT), no uploads.
 
 ### Converters
 


### PR DESCRIPTION
https://abox.tools/

Browser-side PDF tools — merge, compress, images to PDF, and redact — added to
the Tools section next to the other client-side suites.

The redaction is what makes it worth a separate line: it deletes the glyphs
from the content stream and inserts a kern so the remaining text keeps its
position, rather than drawing a black rectangle over words that stay selectable
and copyable underneath. It also strips `/ActualText`, which is where a copy of
the removed words otherwise survives a redaction.

Open source, MIT: https://github.com/A-Box-of-Tools/website

🤖 Generated with [Claude Code](https://claude.com/claude-code)
