### PR TITLE
Add AccuPDF to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [Rails PDF](https://github.com/igorkasyanchuk/rails_pdf) - Create PDF documents from HTML in Ruby on Rails.
 
 ## Tools
+- [AccuPDF](https://accupdf.com/) - Free browser-based PDF suite — merge, split, compress, OCR, convert, fill forms, redact, and more. All processing runs client-side; files are never uploaded.
 - [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free browser-based PDF tools. Compress, merge, split, convert. All local WebAssembly processing — no file uploads.
 - [hushvert](https://hushvert.com) - Privacy-first browser-based PDF tools. Merge, split, rotate, and render PDFs locally via WebAssembly with no file uploads, plus a hosted API for PDF to Word and Office to PDF.
 - [OnDevicePDF](https://www.ondevicepdf.com) - Free browser-based PDF tools — merge, split, compress, edit, sign, OCR. The security tools (password protect/remove/recover, redact) run under a sealed CSP so files provably never leave the browser; live proof at [ondevicepdf.com/verify](https://www.ondevicepdf.com/verify).


### PR DESCRIPTION
Adds [AccuPDF](https://accupdf.com/) to the Tools section — a free, fully client-side PDF suite (merge, split, compress, OCR, convert, fill forms, redact) where files are never uploaded. Same category as the existing browser-based entries like PDFGem.