### PR TITLE
Add Protect PDF to Tools/Misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDF Tool HQ](https://pdftoolhq.com/) - Free browser-based PDF tools to merge, split, and compress. Runs entirely client-side, so files never leave your device. No upload, no sign-up, no watermarks.
 - [KeyPDF](https://keypdf.net) - An independent, client-side PDF engine for editing existing PDF text, merges, annotations and filling forms directly in the browser without uploading files.
 - [Preflighter](https://preflighter.app) - Free browser-based prepress preflight and soft-proof for print-ready PDFs: color separations (CMYK + spot/Pantone) with per-plate toggles, overprint preview, total ink coverage (TAC) heatmap with adjustable threshold, densitometer, and font/image/page-box inspection. No signup; files are processed server-side and auto-deleted after 24 hours.
+- [Protect PDF](https://nutilz.com/protect-pdf) - Free tool to add AES-256 password encryption to a PDF. No signup; files are processed server-side over HTTPS and discarded immediately after the download completes.
 
 ## Software
 


### PR DESCRIPTION
Adds [Protect PDF](https://nutilz.com/protect-pdf), a free tool to add AES-256 password encryption to a PDF. No signup required; files are processed server-side over HTTPS and discarded immediately after the download completes. Part of nutilz.com's free tools collection (PDF, text, image, and developer utilities).