### PR TITLE
Converters: remove dead Fluranto and TinyTools links, add file2markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [Markdown Resume Generator](https://github.com/there4/markdown-resume) - PHP tool to convert markdown to PDF and HTML résumés.
 - [paper2md](https://paper2md.com/) - Web tool to convert academic and technical PDFs into clean Markdown. Preserves LaTeX formulas (KaTeX/MathJax/Obsidian compatible), converts complex research tables to valid GFM Markdown, and extracts figures into a ZIP. Free for 100 pages/month.
 - [CopyMarkdown](https://copymarkdown.com/pdf-to-markdown/) - Free web tool to convert PDFs to clean Markdown. A companion [Chrome extension](https://chromewebstore.google.com/detail/bafbipicilofikmmjdeckfjghfdffdgp) converts webpages and AI chat conversations, and a separate free web tool converts GitHub repos. No signup required.
+- [file2markdown](https://www.file2markdown.ai/convert/pdf-to-markdown) - Browser-based PDF/DOCX/PPTX/XLSX/HTML/EPUB/URL to Markdown converter that keeps headings and tables; AI OCR for scanned PDFs. Free tier, no signup; MCP server for AI assistants.
 
 ### Misc
 
@@ -208,13 +209,11 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDFGem](https://pdfgem.io/) - Free browser-based PDF tools — merge, split, compress, OCR, sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser.
 - [PDFSass](https://pdfsass.com/) - Free browser-based PDF toolkit with 35+ tools — merge, split, compress, convert, OCR, rotate, watermark, sign, and more. No signup required; files processed in-browser via WebAssembly.
 - [Slay PDF](https://slaypdf.com/) - Free local browser PDF editor for splitting, merging, signing, resizing, posterising, OCR and page editing. Open source and client-side.
-- [Fluranto](https://www.fluranto.com/en/pdf) - Browser-based PDF tools with no signup. Merge, split, reorder, rotate, extract pages, add page numbers, watermark, and convert between images and PDF.
 - [DoItSwift](https://doitswift.com/pdf/) - Free browser-based PDF tools — merge, split, compress, and PDF to JPG. No Server/Cloud upload, no signup. Everything runs locally in your browser.
 - [AllPDFMagic](https://allpdfmagic.com) - Free online PDF toolbox with 33+ tools and AI-powered workflows. Merge, split, compress, convert, edit, sign, and protect PDFs with zero signup. Features AI Summarizer, Invoice Extractor, Contract Analyzer, and Multi-PDF Chat.
 - [PDFMatePro](https://www.pdfmatepro.com/) - Free browser-based PDF toolkit with 75+ tools — merge, split, compress, OCR (30+ languages including Urdu/Arabic), sign, convert, and more. Client-side processing via WebAssembly; files never leave the browser. Includes region-specific tools like CNIC-to-PDF and fee challan-to-PDF for Pakistani users.
 - [pdfparanoia](https://github.com/kanzure/pdfparanoia) - Watermark removal tool in Python.
 - [questio](https://github.com/abcreativ/questio) - Forensic PDF auditor CLI for detecting edited, forged, or tampered PDFs. Runs locally, no uploads.
-- [TinyTools](https://tinytools-smoky.vercel.app/) - Free browser-based PDF utilities with no signup. Includes Chat with PDF (ask questions about a PDF) and PDF to Markdown (extract structured Markdown from PDFs). Client-side processing; part of a larger suite of single-purpose web tools. Open source.
 - [ClientPDF](https://abyworkings-coder.github.io/clientpdf/) - Free, client-side tool to merge PDF files entirely in the browser via pdf-lib. No upload, no signup, no server.
 - [PDF Toolbox](https://pdftoolbox-three.vercel.app) - Free, privacy-first online PDF toolkit — merge, split, compress, convert, OCR, e-sign, and more. All processing is client-side; files never leave the browser.
 - [MoGuan (墨观)](https://moguanpdf.com) - Privacy-first browser PDF toolkit with 24 tools (merge, split, compress, OCR, watermark, sign, convert to Word/Excel, encrypt). The 20 classic/edit/convert tools run fully client-side via pdf.js + pdf-lib — files never uploaded, verifiable in the DevTools Network panel. Chinese-first, bilingual (zh/en), installable PWA.


### PR DESCRIPTION
- Fluranto (`fluranto.com/en/pdf`) and TinyTools (`tinytools-smoky.vercel.app`) both return 404 — removed.
- Added file2markdown to Converters next to CopyMarkdown: browser-based PDF/DOCX/PPTX/XLSX/HTML/EPUB/URL to Markdown converter, keeps headings and tables, AI OCR for scanned PDFs, free tier with no signup, MCP server.

Disclosure: I maintain file2markdown; happy to drop that addition if it doesn't fit the list's criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)