### PR TITLE
Add JustFill for filling existing PDF forms from Excel/CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ If you have a question or aren’t sure if something is worth including, you can
 
 ### Misc
 
+- [JustFill](https://justfill.app/solutions/fill-pdf-from-excel) - Hosted PDF form filler with reusable field layouts and Excel/CSV batch filling. Account required; free allowance and paid plans.
 - [Sejda](https://www.sejda.com/) - Whole suite of PDF services, including conversion, security, manipulation, and more.
 - [Potrivit](https://www.cbinsights.com/company/potrivit-beautiful-pdf-invoices) - Design PDF invoices.
 - [PDFElement](https://pdf.wondershare.com/) - Software for editing, creating, conversion, and more.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,6 @@ If you have a question or aren’t sure if something is worth including, you can
 
 ### Misc
 
-- [JustFill](https://justfill.app/solutions/fill-pdf-from-excel) - Hosted PDF form filler with reusable field layouts and Excel/CSV batch filling. Account required; free allowance and paid plans.
 - [Sejda](https://www.sejda.com/) - Whole suite of PDF services, including conversion, security, manipulation, and more.
 - [Potrivit](https://www.cbinsights.com/company/potrivit-beautiful-pdf-invoices) - Design PDF invoices.
 - [PDFElement](https://pdf.wondershare.com/) - Software for editing, creating, conversion, and more.
@@ -222,6 +221,7 @@ If you have a question or aren’t sure if something is worth including, you can
 - [PDF Tool HQ](https://pdftoolhq.com/) - Free browser-based PDF tools to merge, split, and compress. Runs entirely client-side, so files never leave your device. No upload, no sign-up, no watermarks.
 - [KeyPDF](https://keypdf.net) - An independent, client-side PDF engine for editing existing PDF text, merges, annotations and filling forms directly in the browser without uploading files.
 - [Preflighter](https://preflighter.app) - Free browser-based prepress preflight and soft-proof for print-ready PDFs: color separations (CMYK + spot/Pantone) with per-plate toggles, overprint preview, total ink coverage (TAC) heatmap with adjustable threshold, densitometer, and font/image/page-box inspection. No signup; files are processed server-side and auto-deleted after 24 hours.
+- [JustFill](https://justfill.app/solutions/fill-pdf-from-excel) - Hosted PDF form filler with reusable field layouts and Excel/CSV batch filling. Account required; free allowance and paid plans.
 
 ## Software
 


### PR DESCRIPTION
Adds JustFill under Tools / Misc for filling existing PDF forms from spreadsheet rows and reusing reviewed field layouts.

The linked page includes a sample workflow, review and ZIP-export steps, and pricing. This is a hosted service: documents are uploaded, an account is required, and clean batch exports use paid allowances. The entry does not describe it as an unlimited free or local-only tool.

Checked the link and searched the list and existing PRs for duplicates. This changes one README entry only.

Disclosure: submitted for JustFill.
